### PR TITLE
chore: format integration services

### DIFF
--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/integrations.module.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/integrations.module.ts
@@ -1,8 +1,11 @@
-import { Module } from '@nestjs/common';
-import { S3Service } from './s3.service';
-import { PushService } from './push.service';
-import { SmsService } from './sms.service';
-import { OrsService } from './ors.service';
-import { RedisService } from './redis.service';
-@Module({ providers:[S3Service,PushService,SmsService,OrsService,RedisService], exports:[S3Service,PushService,SmsService,OrsService,RedisService] })
+import { Module } from "@nestjs/common";
+import { S3Service } from "./s3.service";
+import { PushService } from "./push.service";
+import { SmsService } from "./sms.service";
+import { OrsService } from "./ors.service";
+import { RedisService } from "./redis.service";
+@Module({
+  providers: [S3Service, PushService, SmsService, OrsService, RedisService],
+  exports: [S3Service, PushService, SmsService, OrsService, RedisService],
+})
 export class IntegrationsModule {}

--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/ors.service.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/ors.service.ts
@@ -1,17 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from "@nestjs/common";
 @Injectable()
 export class OrsService {
   async eta(fromLat: number, fromLon: number, toLat: number, toLon: number) {
     const R = 6371;
-    const toRad = (d: number) => d * Math.PI / 180;
+    const toRad = (d: number) => (d * Math.PI) / 180;
     const dLat = toRad(toLat - fromLat);
     const dLon = toRad(toLon - fromLon);
-    const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
-              Math.cos(toRad(fromLat)) * Math.cos(toRad(toLat)) *
-              Math.sin(dLon/2) * Math.sin(dLon/2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(toRad(fromLat)) *
+        Math.cos(toRad(toLat)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     const distKm = R * c;
-    const etaMin = Math.max(3, Math.round(distKm / 30 * 60));
+    const etaMin = Math.max(3, Math.round((distKm / 30) * 60));
     return etaMin;
   }
 }

--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/push.service.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/push.service.ts
@@ -1,1 +1,7 @@
-import { Injectable } from '@nestjs/common'; @Injectable() export class PushService { async notifyUser(userId:string, payload:any){ console.log('Push to', userId, payload?.title || payload); } }
+import { Injectable } from "@nestjs/common";
+@Injectable()
+export class PushService {
+  async notifyUser(userId: string, payload: any) {
+    console.log("Push to", userId, payload?.title || payload);
+  }
+}

--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/redis.service.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/redis.service.ts
@@ -1,1 +1,21 @@
-import { Injectable } from '@nestjs/common'; import Redis from 'ioredis'; @Injectable() export class RedisService { client: any; constructor(){ this.client = new Redis({ host: process.env.REDIS_HOST || 'redis', port: Number(process.env.REDIS_PORT||6379) }); } async softLockJob(jobId:string, workerId:string, ttlMs=90000){ const key=`job:${jobId}:softlock`; const res = await this.client.set(key, workerId, 'PX', ttlMs, 'NX'); return res==='OK'; } async softLockInfo(jobId:string){ const key=`job:${jobId}:softlock`; return this.client.get(key); } }
+import { Injectable } from "@nestjs/common";
+import Redis from "ioredis";
+@Injectable()
+export class RedisService {
+  client: any;
+  constructor() {
+    this.client = new Redis({
+      host: process.env.REDIS_HOST || "redis",
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
+  async softLockJob(jobId: string, workerId: string, ttlMs = 90000) {
+    const key = `job:${jobId}:softlock`;
+    const res = await this.client.set(key, workerId, "PX", ttlMs, "NX");
+    return res === "OK";
+  }
+  async softLockInfo(jobId: string) {
+    const key = `job:${jobId}:softlock`;
+    return this.client.get(key);
+  }
+}

--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/s3.service.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/s3.service.ts
@@ -1,1 +1,10 @@
-import { Injectable } from '@nestjs/common'; @Injectable() export class S3Service { async presignPut(key:string, contentType:string){ return { url:`https://example-r2.local/upload/${encodeURIComponent(key)}`, key }; } }
+import { Injectable } from "@nestjs/common";
+@Injectable()
+export class S3Service {
+  async presignPut(key: string, contentType: string) {
+    return {
+      url: `https://example-r2.local/upload/${encodeURIComponent(key)}`,
+      key,
+    };
+  }
+}

--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/sms.service.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/sms.service.ts
@@ -1,1 +1,8 @@
-import { Injectable } from '@nestjs/common'; @Injectable() export class SmsService { async send(to:string, message:string){ console.log('SMS', to, message); return { ok:true, to, message }; } }
+import { Injectable } from "@nestjs/common";
+@Injectable()
+export class SmsService {
+  async send(to: string, message: string) {
+    console.log("SMS", to, message);
+    return { ok: true, to, message };
+  }
+}


### PR DESCRIPTION
## Summary
- format integration module and services with Prettier for readability

## Testing
- `npx prettier backend/src/integrations/*.ts --check`
- `npx tsc --noEmit` *(fails: Cannot find module '@nestjs/config' and './modules/jobs/jobs.module')*

------
https://chatgpt.com/codex/tasks/task_e_68b3518e5e888333b063e6b3efc0e6b6