### PR TITLE
Inject RedisService into JobsController

### DIFF
--- a/mazdoorhub-v2-fixed-repo/backend/src/integrations/integrations.module.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/integrations/integrations.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
-import { S3Service } from './s3.service';
+
 import { PushService } from './push.service';
+import { RedisService } from './redis.service';
+import { S3Service } from './s3.service';
 import { SmsService } from './sms.service';
 import { OrsService } from './ors.service';
-import { RedisService } from './redis.service';
-@Module({ providers:[S3Service,PushService,SmsService,OrsService,RedisService], exports:[S3Service,PushService,SmsService,OrsService,RedisService] })
+
+@Module({
+  providers: [S3Service, PushService, SmsService, OrsService, RedisService],
+  exports: [S3Service, PushService, SmsService, OrsService, RedisService],
+})
 export class IntegrationsModule {}


### PR DESCRIPTION
## Summary
- register RedisService provider inside IntegrationsModule
- inject RedisService into JobsController and reuse in peek instead of manual instantiation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '@nestjs/config' and './modules/jobs/jobs.module')*


------
https://chatgpt.com/codex/tasks/task_e_68b3536b475483339433b80712405da8