### PR TITLE
Use upsert for device heartbeat and add device uniqueness index

### DIFF
--- a/mazdoorhub-v2-fixed-repo/backend/src/modules/devices/devices.controller.ts
+++ b/mazdoorhub-v2-fixed-repo/backend/src/modules/devices/devices.controller.ts
@@ -1,1 +1,19 @@
-import { Controller, Post, Body } from '@nestjs/common'; import { DataSource } from 'typeorm'; @Controller('v1/devices') export class DevicesController { constructor(private ds: DataSource) {} @Post('heartbeat') async heartbeat(@Body() b: { user_id: string; token?: string; platform?: string }){ await this.ds.query(`INSERT INTO devices (user_id, token, platform) VALUES ($1,$2,$3)`, [b.user_id, b.token || null, b.platform || null]); return { ok: true }; } }
+import { Controller, Post, Body } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+@Controller('v1/devices')
+export class DevicesController {
+  constructor(private ds: DataSource) {}
+
+  @Post('heartbeat')
+  async heartbeat(
+    @Body() b: { user_id: string; token?: string; platform?: string },
+  ) {
+    await this.ds.query(
+      `INSERT INTO devices (user_id, token, platform) VALUES ($1,$2,$3) ON CONFLICT (user_id, token) DO UPDATE SET platform=EXCLUDED.platform, created_at=now()`,
+      [b.user_id, b.token || null, b.platform || null],
+    );
+    return { ok: true };
+  }
+}
+

--- a/mazdoorhub-v2-fixed-repo/db/init/14_indexes.sql
+++ b/mazdoorhub-v2-fixed-repo/db/init/14_indexes.sql
@@ -3,3 +3,4 @@ CREATE INDEX IF NOT EXISTS idx_workers_availability ON workers(availability);
 CREATE INDEX IF NOT EXISTS idx_jobs_lon_lat ON jobs(lon, lat);
 CREATE INDEX IF NOT EXISTS idx_workers_lon_lat ON workers(lon, lat);
 CREATE INDEX IF NOT EXISTS idx_ledgers_user_created ON ledgers(user_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_user_token ON devices(user_id, token);


### PR DESCRIPTION
## Summary
- upsert devices on heartbeat, updating platform and timestamp
- ensure devices have unique user/token pair

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@nestjs/config', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3578604008333b50a2d9a816acba6