### PR TITLE
Guard ID-dependent actions in mobile app

### DIFF
--- a/mazdoorhub-v2-fixed-repo/mobile/lib/main.dart
+++ b/mazdoorhub-v2-fixed-repo/mobile/lib/main.dart
@@ -49,7 +49,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   final FlutterTts tts = FlutterTts(); bool speakHints=false;
-  String? jwt; String employerId="00000000-0000-0000-0000-000000000000"; String workerId="00000000-0000-0000-0000-000000000001";
+  String? jwt; String? employerId; String? workerId;
   List<Skill> skills=[]; Skill? selected;
   final titleCtrl = TextEditingController(text: "Plumber needed");
   double lat=24.8607, lon=67.0011; String? lastJobId; Timer? _pollTimer; Timer? heartbeatTimer; double? workerLat, workerLon; String? acceptedWorkerId; String? jobStatus;
@@ -81,7 +81,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> postJob() async {
-    if (selected==null) return;
+    if (selected==null || employerId==null) return;
     final r = await http.post(Uri.parse('$apiBase/v1/jobs'),
       headers:{'Content-Type':'application/json', if(jwt!=null) 'Authorization':'Bearer $jwt'},
       body: jsonEncode({"employer_id":employerId,"skill_id":selected!.id,"title":titleCtrl.text,"lat":lat,"lon":lon,"budget_type":"fixed","budget_amount":2500,"guarantee_min_pkr":2000})
@@ -118,6 +118,7 @@ class _HomePageState extends State<HomePage> {
     await http.patch(Uri.parse('$apiBase/v1/workers/$workerId/preferences'), headers:{'Content-Type':'application/json'}, body: jsonEncode(body));
   }
   Future<void> toggleAvailability() async {
+    if (workerId==null) return;
     available = !available; setState((){});
     await http.patch(Uri.parse('$apiBase/v1/workers/$workerId/availability'), headers:{'Content-Type':'application/json'}, body: jsonEncode({"availability": available}));
     if (speakHints) { await tts.speak(available? 'Available' : 'Unavailable'); }
@@ -143,6 +144,7 @@ class _HomePageState extends State<HomePage> {
   }
   Future<void> sendHeartbeat() async {
     final uid = widget.mode==Mode.worker? workerId : employerId;
+    if (uid==null) return;
     await http.post(Uri.parse('$apiBase/v1/devices/heartbeat'), headers:{'Content-Type':'application/json'}, body: jsonEncode({"user_id": uid, "platform":"flutter"}));
   }
 


### PR DESCRIPTION
## Summary
- Initialize employerId and workerId as null
- Avoid posting jobs, toggling availability, or sending heartbeats without IDs

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b358b1c3f08333a43b5a99b838d1a2